### PR TITLE
Refactor to new URL-based scheme.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
+sudo: false
 language: node_js
 node_js:
-- '0.11'
+- '0.12'
+- '0.10'
+- 'iojs-1'
+before_install:
+- npm install -g "npm@>=1.4.6"
 after_success:
 - npm install coveralls
 - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/README.md
+++ b/README.md
@@ -9,32 +9,34 @@ Use S3 as a source or destination of vinyl files.
 ![downloads](http://img.shields.io/npm/dm/vinyl-s3.svg?style=flat)
 
 Features:
- * Source with globbing support,
+ * Source with multi-globbing support,
  * Use either streaming or buffering,
  * Upload or download files,
+ * Pass custom options to S3,
  * Works great with gulp.
 
+## Usage
 
 ```javascript
 var gulp = require('gulp'),
 	AWS = require('aws-sdk'),
-	s3 = require('vinyl-s3')(new AWS.S3(), { Bucket: 'myBucket' });
+	s3 = require('vinyl-s3');
 
 // Upload files to S3
 gulp.task('upload', function() {
 	return gulp.src('data/*.jpg', { buffer: false })
-		.pipe(s3.dest('prefix'));
+		.pipe(s3.dest('s3://my-bucket/prefix'));
 });
 
 // Download files from S3
 gulp.task('download', function() {
-	return s3.src('prefix/*.jpg', { buffer: false })
+	return s3.src('s3://my-bucket/prefix/*.jpg', { buffer: false })
 		.pipe(gulp.dest('data'));
 });
 
 // Just print a list of files
 gulp.task('meta', function() {
-	return s3.src('/foo/**/*.jpg', { read: false })
+	return s3.src('s3://my-bucket/foo/**/*.jpg', { read: false })
 		.pipe(through2.obj(function(file, _, callback) {
 			console.log('found:',file.path);
 			callback();
@@ -42,4 +44,72 @@ gulp.task('meta', function() {
 })
 ```
 
-When working with large files you may find it useful to use streaming mode instead of buffering mode. You can enable this in the `src()` family of functions by setting `{ buffer: false }`. The default mode is to use buffering.
+When working with large files you may find it useful to use streaming mode instead of buffering mode. You can enable this in the `src()` family of functions by setting `{ buffer: false }`. The default mode is to use buffering as is the same with `fs.src`.
+
+### src
+
+See [getObject] for a list of supported options.
+
+```javascript
+// Specify custom attributes via S3 URL.
+s3.src('s3://bucket/key/*?IfModifiedSince=123456789')
+    .pipe(fs.dest('downloads'));
+```
+
+```javascript
+// Specify custom attributes by passing in an AWS options object.
+src.src({
+    Bucket: 'bucket',
+    Key: 'key/*',
+    IfModifiedSince: Date.now()
+}).pipe(fs.dest('downloads'));
+```
+
+```javascript
+// Use multiple source buckets and patterns.
+s3.src(['s3://bucket1/*.jpg', 's3://bucket1/*.png', 's3://bucket2/*.gif'])
+    .pipe(fs.dest('downloads'));
+```
+
+### dest
+
+See [putObject] for a list of supported options.
+
+```javascript
+// Specify custom attributes via S3 URL.
+fs.src('files/*.jpg')
+    .pipe(s3.dest('s3://bucket/foo?ContentType=image/jpeg'));
+```
+
+```javascript
+// Specify custom attributes by passing in an AWS options object.
+fs.src('files/*.jpg')
+    .pipe(s3.dest({
+        Bucket: 'bucket',
+        Key: 'foo',
+        ContentType: 'image/jpeg'
+    }));
+```
+
+```javascript
+// Specify custom attributes per file.
+fs.src('files/*.jpg')
+    .pipe(through2.obj(function(file, enc, next) {
+        // Setting the awsOptions property on a file causes the object to be
+        // included in the command sent to S3.
+        file.awsOptions = {
+            ACL: 'private',
+            CacheControl: 'max-age=1296000',
+            ContentType: 'image/jpeg',
+            Metadata: {
+                color: 'red'
+            }
+        };
+        this.push(file);
+        next();
+    }))
+    .pipe(s3.dest('s3://bucket/foo'));
+```
+
+[getObject]: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getObject-property
+[putObject]: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property

--- a/example/download.js
+++ b/example/download.js
@@ -7,12 +7,10 @@ var argv = require('yargs').argv;
 var path = require('path'),
 	through2 = require('through2'),
 	fs = require('vinyl-fs'),
-	AWS = require('aws-sdk'),
-	vinylS3 = require(path.join(__dirname, '..'));
-
-var s3 = vinylS3(new AWS.S3(), { Bucket: argv.bucket });
+	s3 = require(path.join(__dirname, '..'));
 
 // Download from S3
+// env AWS_PROFILE="home" ./example/upload.js --dest="./" "s3://bucket/*.jpg"
 s3.src(argv._, { buffer: argv.buffer })
 	.pipe(fs.dest(argv.dest))
 	.pipe(through2.obj(function processed(file, enc, callback) {

--- a/example/upload.js
+++ b/example/upload.js
@@ -7,12 +7,10 @@ var argv = require('yargs').argv;
 var path = require('path'),
 	through2 = require('through2'),
 	fs = require('vinyl-fs'),
-	AWS = require('aws-sdk'),
-	S3 = require(path.join(__dirname, '..'));
-
-var s3 = new S3(new AWS.S3(), { Bucket: argv.bucket });
+	s3 = require(path.join(__dirname, '..'));
 
 // Streaming upload to S3
+// env AWS_PROFILE="home" ./example/upload.js --dest="s3://bucket" "./*.jpg"
 fs.src(argv._, { buffer: argv.buffer })
 	.pipe(s3.dest(argv.dest))
 	.pipe(through2.obj(function processed(file, enc, callback) {

--- a/lib/read-stream.js
+++ b/lib/read-stream.js
@@ -2,57 +2,78 @@
 'use strict';
 
 var _ = require('lodash'),
+	AWS = require('aws-sdk'),
 	through2 = require('through2'),
 	S3S = require('s3-streams');
 
 /**
- * Create a stream which takes objects with a { Key: 'foo' } property and converts
- * them to S3 objects. The S3 objects inherit all of the given AWS options.
+ * Check to see whether or not we were actually expecting an error respond code
+ * back. This happens sometimes if we're filtering the results by using some of
+ * the "If"-style headers.
  *
- * @param {AWS.S3} s3 S3 instance.
- * @param {Object} awsOptions Options passed directly to AWS.
- * @param {Object} streamOptions Options for the stream.
- * @param {Boolean} streamOptions.buffer True to use buffering, false for streaming.
- * @param {Boolean} streamOptions.read True to return key content.
- * @param {Boolean} streamOptions.meta True to return key metadata.
+ * IfNoneMatch: 304
+ * IfModifiedSince: 304
+ * IfMatch: 412
+ * IfUnmodifiedSince: 412
+ *
+ * @param {Object} request The AWS options we started with.
+ * @param {Object} error The error we got back in response to the request.
+ * @returns {Boolean} True if the error was expected, false otherwise.
+ */
+function expectedError(request, error) {
+	return (error.code === 304 || error.code === 412);
+}
+
+/**
+ * Create a stream which takes objects with a { Key: 'foo' } property and  turns
+ * them into S3 objects. The S3 objects inherit all of the given AWS options.
+ *
+ * @param {Object} options Options for the stream.
+ * @param {AWS.S3} options.s3 S3 instance.
+ * @param {Object} options.awsOptions Options passed directly to AWS.
+ * @param {Boolean} options.buffer True to buffer, false to stream.
+ * @param {Boolean} options.read True to return key content.
+ * @param {Boolean} options.meta True to return key metadata.
  * @returns {Stream.Transform} The stream.
  */
-module.exports = function createReadStream(s3, awsOptions, streamOptions) {
+module.exports = function createReadStream(options) {
 
-	if (!s3 || !_.isFunction(s3.getObject)) {
+	options = _.assign({
+		buffer: true,
+		read: true,
+		awsOptions: { },
+		s3: new AWS.S3()
+	}, options);
+
+	if (!options.s3 || !_.isFunction(options.s3.getObject)) {
 		throw new TypeError();
 	}
 
-	streamOptions = _.assign({
-		buffer: true,
-		read: true
-	}, streamOptions);
-
 	return through2.obj(function readStream(object, encoding, callback) {
+
+		// Select the appropriate S3 API call based on how the user
+		// wants the data.
+		var request = _.assign({ }, options.awsOptions, object);
 
 		function resolve(err, result) {
 			if (err) {
-				return callback(err);
+				return callback(!expectedError(request, err) ? err : null);
 			} else {
 				return callback(null, _.assign({ }, object, result));
 			}
 		}
 
-		// Select the appropriate S3 API call based on how the user
-		// wants the data.
-		var request = _.assign({ }, awsOptions, _.pick(object, ['Key', 'Bucket']));
-
-		if (streamOptions.read && streamOptions.buffer) {
-			s3.getObject(request, resolve);
-		} else if (streamOptions.read && !streamOptions.buffer) {
-			S3S.ReadStream(s3, request)
+		if (options.read && options.buffer) {
+			options.s3.getObject(request, resolve);
+		} else if (options.read && !options.buffer) {
+			S3S.ReadStream(options.s3, request)
 				.on('open', function open(headers) {
 					resolve(null, _.assign(headers, { Body: this }));
 				})
 				.on('error', resolve)
 				.read(0); // Trigger initial read for open event
 		} else {
-			s3.headObject(request, resolve);
+			options.s3.headObject(request, resolve);
 		}
 	});
 };

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -9,33 +9,31 @@ var _ = require('lodash'),
 
 /**
  * @constructor
- * @param {AWS.S3} s3 S3 instance.
- * @param {Object} awsOptions Default settings.
+ * @param {Object} options Default settings.
  */
-function S3(s3, awsOptions) {
+function S3(options) {
 	// `new` short-circuiting
 	if (this instanceof S3 === false) {
-		return new S3(s3, awsOptions);
+		return new S3(options);
 	}
-
-	// Assign local variables
-	this.s3 = s3;
-	this.awsOptions = awsOptions;
+	this.options = options;
 }
+
 
 /**
  * Fetch vinyl objects from S3 matching a specific set of glob patterns.
  * This method behaves in much the same way as `gulp.src` does.
  *
- * @param {Array|String} path List of glob patterns to fetch.
+ * @param {Array|String|Object} path List of glob patterns to fetch.
  * @param {Object} options Options.
- * @returns {Stream} Stream emitting vinyl objects corresponding to objects in S3.
+ * @returns {Stream} Stream emitting vinyl corresponding to objects in S3.
  *
  * @see gulp.src
  */
-S3.prototype.src = function src(path, options) {
-	return S3G(this.s3, this.awsOptions, path)
-		.pipe(readStream(this.s3, this.awsOptions, options))
+S3.src = function src(path, options) {
+	options = _.assign({ format: 'query' }, options);
+	return S3G(path, options)
+		.pipe(readStream(options))
 		.pipe(vinylStream(options));
 };
 
@@ -43,13 +41,23 @@ S3.prototype.src = function src(path, options) {
  * Create a stream which, when sent vinyl objects, uploads those
  * objects to S3 and then re-emits those objects.
  *
- * @param {String} path Prefix to save objects under in S3.
+ * @param {String|Object} path Prefix to save objects under in S3.
+ * @param {Object} options Stream options.
  * @returns {Stream} Stream emitting same the vinyl as piped in.
  *
  * @see vinyl-fs.dest
  */
-S3.prototype.dest = function dest(path) {
-	return writeStream(this.s3, _.assign({ }, this.awsOptions, { Key: path }));
+S3.dest = function dest(path, options) {
+	return writeStream(path, options);
+};
+
+
+S3.prototype.src = function wrapSrc(path, options) {
+	return S3.src(path, _.assign({ }, this.options, options));
+};
+
+S3.prototype.dest = function wrapDest(path, options) {
+	return S3.dest(path, _.assign({ }, this.options, options));
 };
 
 module.exports = S3;

--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -2,29 +2,50 @@
 'use strict';
 
 var _ = require('lodash'),
+	AWS = require('aws-sdk'),
 	through2 = require('through2'),
-	S3S = require('s3-streams');
+	S3S = require('s3-streams'),
+	url = require('s3-url');
 
 /**
  * Create a stream which can be piped vinyl files that get uploaded to S3.
  * Once the files have finished being uploaded, they will be re-emitted so
  * that other streams can re-use them later in the pipeline.
  *
- * @param {AWS.S3} s3 S3 instance.
- * @param {Object} awsOptions Settings for AWS.
- * @param {String} awsOptions.Bucket Destination bucket to write files to.
- * @param {String} awsOptions.Key Prefix for all files.
+ * Vinyl files that have the `awsOptions` property set automatically have those
+ * options passed through to S3.
+ *
+ * @param {String|Object} path Destination to write to.
+ * @param {Object} options Stream options.
+ * @param {AWS.S3} options.s3 S3 instance.
+ * @param {String} options.base Prefix for all keys.
+ * @param {Object} options.awsOptions Settings for AWS.
+ * @param {String} options.awsOptions.Bucket Destination bucket to write to.
  * @returns {Stream.Transform} Stream.
  */
-module.exports = function createWriteStream(s3, awsOptions) {
+module.exports = function createWriteStream(path, options) {
+
+	options = _.assign({
+		s3: new AWS.S3(),
+		awsOptions: { }
+	}, options);
+
+	var s3 = options.s3,
+		awsOptions = options.awsOptions,
+		prefix;
 
 	if (!s3 || !_.isFunction(s3.putObject)) {
 		throw new TypeError();
 	}
 
+	_.assign(awsOptions, _.isString(path) ? url.urlToOptions(path) : path);
+
 	if (!_.has(awsOptions, 'Bucket')) {
 		throw new TypeError();
 	}
+
+	prefix = awsOptions.Key ? awsOptions.Key + '/' : '';
+
 
 	return through2.obj(function writeStream(file, encoding, callback) {
 
@@ -33,9 +54,9 @@ module.exports = function createWriteStream(s3, awsOptions) {
 		}
 
 		var fileOptions = _.assign({ }, awsOptions, {
-			Key: (awsOptions.Key ? awsOptions.Key + '/' : '') + file.path.substr(file.base.length + 1),
+			Key: prefix + file.relative,
 			ContentType: file.contentType || 'application/octet-stream'
-		});
+		}, file.awsOptions);
 
 		if (file.isStream()) {
 			file.contents.pipe(new S3S.WriteStream(s3, fileOptions))

--- a/package.json
+++ b/package.json
@@ -18,27 +18,27 @@
 		"coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100"
 	},
 	"dependencies": {
-		"lodash": "*",
-		"vinyl": "*",
-		"through2": "1.x",
-		"through2-map": "1.x",
-		"s3-glob": ">=0.1.1",
-		"s3-streams": ">=0.1.1"
-	},
-	"peerDependencies": {
-		"aws-sdk": "*"
+		"aws-sdk": "^2.1.8",
+		"lodash": "^3.1.0",
+		"vinyl": "^0.4.6",
+		"through2": "^1.1.1",
+		"through2-map": "^1.4.0",
+		"s3-glob": "^0.2.0",
+		"s3-streams": "^0.1.1",
+		"s3-url": "^0.2.2"
 	},
 	"devDependencies": {
-		"eslint": "*",
-		"eslint-plugin-nodeca": "*",
-		"mocha": "*",
-		"istanbul": "*",
-		"chai": "*",
-		"chai-things": "*",
-		"sinon": "*",
-		"sinon-chai": "*"
+		"eslint": "^0.14.0",
+		"eslint-plugin-nodeca": "^1.0.3",
+		"mocha": "^2.1.0",
+		"istanbul": "^0.3.5",
+		"chai": "^1.10.0",
+		"chai-things": "^0.2.0",
+		"sinon": "^1.12.2",
+		"sinon-chai": "^2.6.0"
 	},
 	"engines": {
-		"node": ">=0.11"
+		"node": "^0.8 || ^0.11 || ^0.12",
+		"iojs": "^1.0.0"
 	}
 }

--- a/test/spec/read-stream.spec.js
+++ b/test/spec/read-stream.spec.js
@@ -1,7 +1,7 @@
 
 'use strict';
 
-var Stream = require('stream'),
+var through2 = require('through2'),
 	S3S = require('s3-streams'),
 	createReadStream = require('read-stream');
 
@@ -20,16 +20,56 @@ describe('#createReadStream', function() {
 		this.sandbox.restore();
 	});
 
-	it('should throw a TypeError when no S3 instance is provided', function() {
-		expect(createReadStream).to.throw(TypeError);
+	it('should throw `TypeError` when no S3 instance provided', function() {
+		expect(function() {
+			createReadStream({ s3: null });
+		}).to.throw(TypeError);
+	});
+
+	it('should throw `TypeError` when bad S3 instance provided', function() {
+		expect(function() {
+			createReadStream({ s3: { } });
+		}).to.throw(TypeError);
+	});
+
+	describe('errors', function() {
+		beforeEach(function() {
+			this.source = through2.obj();
+			this.stream = createReadStream({
+				s3: this.s3,
+				buffer: true,
+				read: true
+			});
+			this.source.pipe(this.stream);
+		});
+		it('should skip `304` when `IfNoneMatch`', function() {
+			this.s3.getObject.callsArgWith(1, { code: 304 });
+			this.source.end({ Key: 'banana', Bucket: 'apple' });
+			this.stream.read(0);
+		});
+		it('should skip `304` when `IfModifiedSince`', function() {
+			this.s3.getObject.callsArgWith(1, { code: 304 });
+			this.source.end({ Key: 'banana', Bucket: 'apple' });
+			this.stream.read(0);
+		});
+		it('should skip `412` when `IfMatch`', function() {
+			this.s3.getObject.callsArgWith(1, { code: 412 });
+			this.source.end({ Key: 'banana', Bucket: 'apple' });
+			this.stream.read(0);
+		});
+		it('should skip `412` when `IfUnmodifiedSince`', function() {
+			this.s3.getObject.callsArgWith(1, { code: 412 });
+			this.source.end({ Key: 'banana', Bucket: 'apple' });
+			this.stream.read(0);
+		});
 	});
 
 	describe('buffering', function() {
 		it('should buffer by default', function() {
 			var object = { Key: 'banana', Bucket: 'apple' },
-				stream = new Stream.PassThrough({ objectMode: true });
+				stream = through2.obj();
 
-			stream.pipe(createReadStream(this.s3)).read(0);
+			stream.pipe(createReadStream({ s3: this.s3 })).read(0);
 			stream.end(object);
 
 			expect(this.s3.getObject).to.be.calledOnce;
@@ -39,23 +79,30 @@ describe('#createReadStream', function() {
 	describe('streaming', function() {
 		beforeEach(function() {
 			this.object = { Key: 'banana', Bucket: 'apple' };
-			this.stream = new Stream.PassThrough({ objectMode: true });
-			this.source = new Stream.PassThrough({ objectMode: true });
-			this.result = this.stream.pipe(createReadStream(this.s3, { }, { buffer: false }));
+			this.stream = through2.obj();
+			this.source = through2.obj();
+			this.result = this.stream.pipe(createReadStream({
+				s3: this.s3,
+				buffer: false
+			}));
 			S3S.ReadStream.returns(this.source);
 		});
 
-		it('should produce files with streams when streaming is enabled', function() {
+		it('should produce files with streams', function() {
 			this.result.read(0);
 			this.stream.end(this.object);
 			expect(S3S.ReadStream).to.be.calledOnce;
 		});
 
-		it('should pass the correct information through on the stream open event', function() {
+		it('should pass correct information through open event', function() {
 			this.result.read(0);
 			this.stream.end(this.object);
 			this.source.emit('open', { Key: 'foo' });
-			expect(this.result.read()).to.include({ Key: 'foo', Body: this.source, Bucket: 'apple' });
+			expect(this.result.read()).to.include({
+				Key: 'foo',
+				Body: this.source,
+				Bucket: 'apple'
+			});
 		});
 
 		it('should pass through the stream error event', function(done) {
@@ -73,11 +120,11 @@ describe('#createReadStream', function() {
 
 
 
-	it('should produce files with no contents when read is disabled', function() {
+	it('should produce files without content when read disabled', function() {
 		var object = { Key: 'banana', Bucket: 'apple' },
-			stream = new Stream.PassThrough({ objectMode: true });
+			stream = through2.obj();
 
-		stream.pipe(createReadStream(this.s3, { }, { read: false })).read(0);
+		stream.pipe(createReadStream({ s3: this.s3, read: false })).read(0);
 		stream.end(object);
 
 		expect(this.s3.headObject).to.be.calledOnce;

--- a/test/spec/vinyl-stream.spec.js
+++ b/test/spec/vinyl-stream.spec.js
@@ -24,13 +24,13 @@ describe('#createVinylStream', function() {
 		expect(stream.read()).to.include({ cwd: 'test' });
 	});
 
-	it('should correctly map `Bucket` to `base`', function() {
+	it('should correctly map `Bucket` -> `base`', function() {
 		var stream = createVinylStream(), body = new Buffer(24);
 		stream.write({ Bucket: 'test', Key: 'key', Body: body });
 		expect(stream.read()).to.include({ base: 'test' });
 	});
 
-	it('should correctly map `LastModified` to the `fs.Stat` object', function() {
+	it('should correctly map `LastModified` -> `fs.Stat` object', function() {
 		var stream = createVinylStream(), date = new Date(), body = new Buffer(24);
 		stream.write({ LastModified: date, Key: 'key', Body: body });
 		expect(stream.read().stat.mtime.toString()).to.equal(date.toString());


### PR DESCRIPTION
Updates documentation, .travis.yml, dependencies, specs and more. Basically this makes it much more straightforward to use since you no longer need to pass an obscure variety objects into `.src` and `.dest` (though you still can if you want to).