### PR TITLE
Add slightly smarter content-type detection via `mime`.

### DIFF
--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var _ = require('lodash'),
+	mime = require('mime'),
 	AWS = require('aws-sdk'),
 	through2 = require('through2'),
 	S3S = require('s3-streams'),
@@ -55,7 +56,7 @@ module.exports = function createWriteStream(path, options) {
 
 		var fileOptions = _.assign({ }, awsOptions, {
 			Key: prefix + file.relative,
-			ContentType: file.contentType || 'application/octet-stream'
+			ContentType: file.contentType || mime.lookup(file.path)
 		}, file.awsOptions);
 
 		if (file.isStream()) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 	"dependencies": {
 		"aws-sdk": "^2.1.8",
 		"lodash": "^3.1.0",
+		"mime": "^1.3.4",
 		"vinyl": "^0.4.6",
 		"through2": "^1.1.1",
 		"through2-map": "^1.4.0",


### PR DESCRIPTION
Ideally we would be using something like `libmagic` to do this, but it's kind of a heavyweight solution and platform dependant. So for now, just use the handy `mime` module to lookup a best guess based on the extension. If someone needs something more accurate they can always set `contentType`.