### PR TITLE
Add support for automatic content encoding detection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ s3.src(['s3://bucket1/*.jpg', 's3://bucket1/*.png', 's3://bucket2/*.gif'])
 
 ### dest
 
-See [putObject] for a list of supported options.
+See [putObject] for a list of supported options. There is limited support for automatically detecting the correct `Content-Type` and correct `Content-Encoding`.
 
 ```javascript
 // Specify custom attributes via S3 URL.
@@ -95,8 +95,14 @@ fs.src('files/*.jpg')
 // Specify custom attributes per file.
 fs.src('files/*.jpg')
     .pipe(through2.obj(function(file, enc, next) {
+        // There are some non-standard properties on the file object that
+        // are used to generate certain AWS options.
+        file.contentType = 'image/jpeg';
+        file.contentEncoding = 'gzip';
+
         // Setting the awsOptions property on a file causes the object to be
-        // included in the command sent to S3.
+        // included in the command sent to S3. These options override any
+        // previously set value.
         file.awsOptions = {
             ACL: 'private',
             CacheControl: 'max-age=1296000',

--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -2,11 +2,17 @@
 'use strict';
 
 var _ = require('lodash'),
+	path = require('path'),
 	mime = require('mime'),
 	AWS = require('aws-sdk'),
 	through2 = require('through2'),
 	S3S = require('s3-streams'),
 	url = require('s3-url');
+
+var encodings = {
+	'gz': 'gzip',
+	'xz': 'xz'
+};
 
 /**
  * Create a stream which can be piped vinyl files that get uploaded to S3.
@@ -16,7 +22,7 @@ var _ = require('lodash'),
  * Vinyl files that have the `awsOptions` property set automatically have those
  * options passed through to S3.
  *
- * @param {String|Object} path Destination to write to.
+ * @param {String|Object} root Destination to write to.
  * @param {Object} options Stream options.
  * @param {AWS.S3} options.s3 S3 instance.
  * @param {String} options.base Prefix for all keys.
@@ -24,7 +30,7 @@ var _ = require('lodash'),
  * @param {String} options.awsOptions.Bucket Destination bucket to write to.
  * @returns {Stream.Transform} Stream.
  */
-module.exports = function createWriteStream(path, options) {
+module.exports = function createWriteStream(root, options) {
 
 	options = _.assign({
 		s3: new AWS.S3(),
@@ -39,7 +45,7 @@ module.exports = function createWriteStream(path, options) {
 		throw new TypeError();
 	}
 
-	_.assign(awsOptions, _.isString(path) ? url.urlToOptions(path) : path);
+	_.assign(awsOptions, _.isString(root) ? url.urlToOptions(root) : root);
 
 	if (!_.has(awsOptions, 'Bucket')) {
 		throw new TypeError();
@@ -54,9 +60,46 @@ module.exports = function createWriteStream(path, options) {
 			callback(err, file);
 		}
 
+		var name = path.basename(file.path),
+			contentType = file.contentType,
+			contentEncoding = file.contentEncoding;
+
+		// If the file extensions match a known encoding and there isn't an
+		// encoding set for the file then use the ones we guessed at.
+		if (!contentEncoding) {
+			contentEncoding = _.chain(name.split('.'))
+				.takeRightWhile(function checkPart(ext) {
+					return encodings[ext];
+				})
+				.map(function encodePart(ext) {
+					return encodings[ext];
+				})
+				.value();
+		}
+
+		// If there is a content encoding set then strip off any extensions
+		// that are from the encoding processes to get the extension for the
+		// "real" content type.
+		if (contentEncoding.length > 0 && !contentType) {
+			var last = _.chain(name.split('.'))
+				.dropRightWhile(function checkPart(ext) {
+					return _.contains(contentEncoding, encodings[ext]);
+				})
+				.last()
+				.value();
+			contentType = mime.lookup(last);
+		}
+
+		// If we still haven't got a content type, then make it our best guess
+		// from the file name.
+		if (!contentType) {
+			contentType = mime.lookup(name);
+		}
+
 		var fileOptions = _.assign({ }, awsOptions, {
 			Key: prefix + file.relative,
-			ContentType: file.contentType || mime.lookup(file.path)
+			ContentType: contentType,
+			ContentEncoding: contentEncoding.join(',')
 		}, file.awsOptions);
 
 		if (file.isStream()) {

--- a/test/spec/write-stream.spec.js
+++ b/test/spec/write-stream.spec.js
@@ -116,4 +116,48 @@ describe('#createWriteStream', function() {
 		this.stream.end(file);
 		expect(this.stream.read()).to.equal(file);
 	});
+
+	it('should respect explicitly set content encoding', function() {
+		var file = new File({
+			path: 'foo.css',
+			base: '',
+			contents: new Buffer(100)
+		});
+		var stream = createWriteStream('s3://foo/bar', { s3: this.s3 });
+		file.contentEncoding = [ 'gzip' ];
+		stream.end(file);
+		expect(this.s3.putObject).to.be.calledWithMatch({
+			ContentType: 'text/css',
+			ContentEncoding: 'gzip'
+		});
+	});
+
+	it('should respect explicitly set content type', function() {
+		var file = new File({
+			path: 'foo.css',
+			base: '',
+			contents: new Buffer(100)
+		});
+		var stream = createWriteStream('s3://foo/bar', { s3: this.s3 });
+		file.contentType = 'application/x-css';
+		stream.end(file);
+		expect(this.s3.putObject).to.be.calledWithMatch({
+			ContentType: 'application/x-css',
+			ContentEncoding: ''
+		});
+	});
+
+	it('should detect correct content encoding', function() {
+		var file = new File({
+			path: 'foo.css.gz',
+			base: '',
+			contents: new Buffer(100)
+		});
+		var stream = createWriteStream('s3://foo/bar', { s3: this.s3 });
+		stream.end(file);
+		expect(this.s3.putObject).to.be.calledWithMatch({
+			ContentType: 'text/css',
+			ContentEncoding: 'gzip'
+		});
+	});
 });


### PR DESCRIPTION
Albeit somewhat brittle, this preliminary support for automatically detecting the correct content encoding allows for the correct headers to be sent without any kind of manual intervention. It should work just fine with the `gulp-gzip` module and allows for explicit control over the encoding when needed too.