### PR TITLE
ETag functions for multiple files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ fs.src('files/*.jpg')
             ContentType: 'image/jpeg',
             Metadata: {
                 color: 'red'
-            }
+            },
+            ETag: crypto.createHash('md5')
         };
         this.push(file);
         next();
@@ -118,13 +119,16 @@ fs.src('files/*.jpg')
 ```
 
 ```javascript
-// Custom E-Tags
+// Custom E-Tags using sha1; the ETags here must be a function since it applies
+// to a group of files and must return a new ETag builder per file.
 fs.src('files/*.jpg')
     .pipe(s3.dest({
         Bucket: 'bucket',
         Key: 'foo',
         ContentType: 'image/jpeg',
-        ETag: crypto.createHash('sha1')
+        ETag: function() {
+            return crypto.createHash('sha1');
+        }
     }));
 ```
 

--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -102,6 +102,10 @@ module.exports = function createWriteStream(root, options) {
 			ContentEncoding: contentEncoding.join(',')
 		}, file.awsOptions);
 
+		if (_.isFunction(fileOptions.ETag)) {
+			fileOptions.ETag = fileOptions.ETag(file);
+		}
+
 		if (file.isStream()) {
 			file.contents.pipe(new S3S.WriteStream(s3, fileOptions))
 				.once('finish', done)

--- a/test/spec/write-stream.spec.js
+++ b/test/spec/write-stream.spec.js
@@ -117,7 +117,9 @@ describe('#createWriteStream', function() {
 				contents: this.source
 			});
 			file.awsOptions = {
-				ETag: crypto.createHash('sha1')
+				ETag: function() {
+					return crypto.createHash('sha1');
+				}
 			};
 			var expected = crypto.createHash('sha1')
 				.update(this.source)


### PR DESCRIPTION
Use functions instead of objects since the context has to be unique on a per file basis.