### PR TITLE
Add missing `isNull` check for mapping vinyl metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Features:
 
 ```javascript
 var gulp = require('gulp'),
-	AWS = require('aws-sdk'),
 	s3 = require('vinyl-s3');
 
 // Upload files to S3
@@ -37,13 +36,14 @@ gulp.task('download', function() {
 });
 
 // Just print a list of files
+var through2 = require('through2');
 gulp.task('meta', function() {
 	return s3.src('s3://my-bucket/foo/**/*.jpg', { read: false })
 		.pipe(through2.obj(function(file, _, callback) {
-			console.log('found:',file.path);
+			console.log(file.path);
 			callback();
 		}));
-})
+});
 ```
 
 When working with large files you may find it useful to use streaming mode instead of buffering mode. You can enable this in the `src()` family of functions by setting `{ buffer: false }`. The default mode is to use buffering as is the same with `fs.src`.

--- a/example/meta.js
+++ b/example/meta.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var argv = require('yargs').argv;
+
+var through2 = require('through2'),
+	s3 = require('vinyl-s3');
+
+// env AWS_PROFILE="home" ./example/meta.js "s3://my-bucket/foo/**/*.jpg"
+s3.src(argv._, { read: false })
+	.pipe(through2.obj(function onFile(file, enc, callback) {
+		console.log(file.path);
+		callback();
+	}))
+	.on('finish', function onFinish() {
+		console.log('Done.');
+	});

--- a/lib/vinyl-stream.js
+++ b/lib/vinyl-stream.js
@@ -37,7 +37,7 @@ module.exports = function createVinylStream(options) {
 
 		// Set the length on things like streams which are used
 		// by some frameworks.
-		if (!file.contents.length) {
+		if (!file.isNull() && !file.contents.length) {
 			file.contents.length = file.stat.size;
 		}
 

--- a/test/spec/vinyl-stream.spec.js
+++ b/test/spec/vinyl-stream.spec.js
@@ -53,4 +53,10 @@ describe('#createVinylStream', function() {
 		stream.write({ ContentType: 'foo/bar', Key: 'key', Body: body, ContentLength: '20' });
 		expect(stream.read().contents).to.have.property('length', 20);
 	});
+
+	it('should work with null vinyl objects', function() {
+		var stream = createVinylStream({ meta: true });
+		stream.write({ ContentType: 'foo/bar', Key: 'key' });
+		expect(stream.read()).to.not.be.null;
+	});
 });


### PR DESCRIPTION
When requesting only metadata (i.e. `{ read: false }`) the check for the `.length` property on the file's contents will fail because the file has no contents. A check is added to deal with this case and a corresponding test has been provided.

Additionally the README has been updated to include an otherwise missing module, and the examples folder now includes an example for just retrieving the metadata.

This fixes https://github.com/izaakschroeder/vinyl-s3/issues/9.