### PR TITLE
Update dependencies to latest versions.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,10 +3,6 @@
 		"node": true
 	},
 
-	"plugins": [
-		"nodeca"
-	],
-
 	"rules": {
 		"brace-style": [2, "1tbs"],
 		"default-case": 2,
@@ -17,6 +13,7 @@
 		"func-names": 2,
 		"func-style": [2, "declaration"],
 		"guard-for-in": 2,
+		"indent": [2, "tab"],
 		"new-cap": 0,
 		"no-floating-decimal": 2,
 		"no-lonely-if": 2,
@@ -25,8 +22,6 @@
 		"no-use-before-define": 2,
 		"no-undefined": 2,
 		"no-underscore-dangle": 0,
-		"nodeca/indent": [2, "tabs", 1],
-		"nodeca/no-lodash-aliases": 2,
 		"quotes": [2, "single"],
 		"radix": 2,
 		"space-after-keywords": [2, "always"],

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
 		"coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100"
 	},
 	"dependencies": {
-		"aws-sdk": "^2.1.8",
-		"lodash": "^3.1.0",
+		"aws-sdk": "^2.1.23",
+		"lodash": "^3.6.0",
 		"mime": "^1.3.4",
 		"vinyl": "^0.4.6",
 		"through2": "^1.1.1",
@@ -29,14 +29,13 @@
 		"s3-url": "^0.2.2"
 	},
 	"devDependencies": {
-		"eslint": "^0.14.0",
-		"eslint-plugin-nodeca": "^1.0.3",
-		"mocha": "^2.1.0",
-		"istanbul": "^0.3.5",
-		"chai": "^1.10.0",
+		"eslint": "^0.19.0",
+		"mocha": "^2.2.4",
+		"istanbul": "^0.3.13",
+		"chai": "^2.2.0",
 		"chai-things": "^0.2.0",
 		"sinon": "^1.12.2",
-		"sinon-chai": "^2.6.0"
+		"sinon-chai": "^2.7.0"
 	},
 	"engines": {
 		"node": "^0.8 || ^0.11 || ^0.12",


### PR DESCRIPTION
This also means we can do away with one of the prior `eslint` plugins as `eslint` now includes native support for indentation.