### PR TITLE
Add `eTag` property when `meta` is enabled.

### DIFF
--- a/lib/vinyl-stream.js
+++ b/lib/vinyl-stream.js
@@ -48,6 +48,11 @@ module.exports = function createVinylStream(options) {
 			if (object.ContentType) {
 				file.contentType = object.ContentType;
 			}
+
+			// Support for E-Tag
+			if (object.ETag) {
+				file.eTag = object.ETag;
+			}
 		}
 
 		return file;

--- a/test/spec/vinyl-stream.spec.js
+++ b/test/spec/vinyl-stream.spec.js
@@ -36,10 +36,16 @@ describe('#createVinylStream', function() {
 		expect(stream.read().stat.mtime.toString()).to.equal(date.toString());
 	});
 
-	it('should collect metadata when meta is enabled', function() {
+	it('should collect `contentType` when meta is enabled', function() {
 		var stream = createVinylStream({ meta: true }), body = new Buffer(24);
 		stream.write({ ContentType: 'foo/bar', Key: 'key', Body: body });
 		expect(stream.read()).to.include({ contentType: 'foo/bar' });
+	});
+
+	it('should collect `eTag` when meta is enabled', function() {
+		var stream = createVinylStream({ meta: true }), body = new Buffer(24);
+		stream.write({ ETag: '1234', Key: 'key', Body: body });
+		expect(stream.read()).to.include({ eTag: '1234' });
 	});
 
 	it('should omit metadata when meta is disabled', function() {


### PR DESCRIPTION
Similar to `contentType` and handled in the exact same manner.

Closes https://github.com/izaakschroeder/vinyl-s3/issues/22