### PR TITLE
Allow disabling of `meta` on reads.

### DIFF
--- a/lib/read-stream.js
+++ b/lib/read-stream.js
@@ -41,6 +41,7 @@ module.exports = function createReadStream(options) {
 	options = _.assign({
 		buffer: true,
 		read: true,
+		meta: true,
 		awsOptions: { },
 		s3: new AWS.S3()
 	}, options);
@@ -72,8 +73,10 @@ module.exports = function createReadStream(options) {
 				})
 				.on('error', resolve)
 				.read(0); // Trigger initial read for open event
-		} else {
+		} else if (options.meta) {
 			options.s3.headObject(request, resolve);
+		} else {
+			resolve(null, request);
 		}
 	});
 };


### PR DESCRIPTION
If you don't need certain properties then this could boost performance. It can be enabled by passing `{ read: false, meta: false }` as options. Existing behavior remains untouched.

Closes https://github.com/izaakschroeder/vinyl-s3/issues/23