### PR TITLE
changes backslashes to forward slashes in relative path before upload…

### DIFF
--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -95,7 +95,7 @@ module.exports = function createWriteStream(root, options) {
 		}
 
 		var fileOptions = _.assign({ }, awsOptions, {
-			Key: prefix + file.relative,
+		    Key: prefix + file.relative.replace(/\\/g,'/'),
 			ContentType: contentType,
 			ContentEncoding: contentEncoding.join(',')
 		}, file.awsOptions);


### PR DESCRIPTION
…ing.

I've run into an issue where backslashes (using vinyl-s3 on windows) don't display correctly the s3 interface (path is treated as a single file rather than a directory hierarchy).  

I know internally S3 doesn't care, but this fix does make it easier to debug and visualize uploads to S3 using the AWS console.