### PR TITLE
Strip empty `ContentEncoding`.

### DIFF
--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -96,9 +96,14 @@ module.exports = function createWriteStream(root, options) {
 
 		var fileOptions = _.assign({ }, awsOptions, {
 			Key: prefix + file.relative,
-			ContentType: contentType,
-			ContentEncoding: contentEncoding.join(',')
+			ContentType: contentType
 		}, file.awsOptions);
+
+		if (contentEncoding.length > 0) {
+			_.assign(fileOptions, {
+				ContentEncoding: contentEncoding.join(',')
+			});
+		}
 
 		if (!file.isNull()) {
 			// Use the new S3 streaming upload API; for more info see

--- a/test/spec/write-stream.spec.js
+++ b/test/spec/write-stream.spec.js
@@ -117,6 +117,19 @@ describe('#createWriteStream', function() {
 		});
 	});
 
+	it('should not set content encoding if not present', function() {
+		var file = new File({
+			path: 'foo.css',
+			base: '',
+			contents: new Buffer(100)
+		});
+		var stream = createWriteStream('s3://foo/bar', { s3: this.s3 });
+		stream.end(file);
+		expect(this.s3.upload).not.to.be.calledWithMatch({
+			ContentEncoding: ''
+		});
+	});
+
 	it('should respect explicitly set content type', function() {
 		var file = new File({
 			path: 'foo.css',
@@ -127,8 +140,7 @@ describe('#createWriteStream', function() {
 		file.contentType = 'application/x-css';
 		stream.end(file);
 		expect(this.s3.upload).to.be.calledWithMatch({
-			ContentType: 'application/x-css',
-			ContentEncoding: ''
+			ContentType: 'application/x-css'
 		});
 	});
 


### PR DESCRIPTION
This actually gets sent back to the client as the empty string and confuses the hell out of cloudfront.