### PR TITLE
allowing s3 to be passed int via options

### DIFF
--- a/lib/read-stream.js
+++ b/lib/read-stream.js
@@ -42,7 +42,7 @@ module.exports = function createReadStream(options) {
 		buffer: true,
 		read: true,
 		awsOptions: { },
-		s3: new AWS.S3()
+		s3: options.s3 || new AWS.S3()
 	}, options);
 
 	if (!options.s3 || !_.isFunction(options.s3.getObject)) {

--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -32,7 +32,7 @@ var encodings = {
 module.exports = function createWriteStream(root, options) {
 
 	options = _.assign({
-		s3: new AWS.S3(),
+		s3: options.s3 || new AWS.S3(),
 		awsOptions: { }
 	}, options);
 


### PR DESCRIPTION
I need to set the profile of S3, to upload a zip file. I have multiple profiles so I use a shared config. Using `new AWS.S3()` as the s3 instance here seems to force the usage of the `AWS_DEFAULT_PROFILE` instead of the one I passed into the options. To fix this, I use a custom s3 that already has been told which profile to use.