### PR TITLE
Fix path handling on win32 systems

### DIFF
--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -94,10 +94,20 @@ module.exports = function createWriteStream(root, options) {
 			contentType = mime.lookup(name);
 		}
 
+		var posixRelative = file.relative;
+		if (path.sep == '\\') {
+			// on win32 replace all backslashes with the slashes that S3 expects as path separators
+			posixRelative = posixRelative.replace(/\\/g,'/')
+		}	
 		var fileOptions = _.assign({ }, awsOptions, {
-			Key: prefix + file.relative,
+			Key: path.posix.normalize(prefix + posixRelative),
 			ContentType: contentType
 		}, file.awsOptions);
+
+		// consider: correct for normalization failure, e.g. fileOptions.Key starts with "../"
+		// which would mean that next write will fail anyway (due to apparent undocumented S3 rule
+		// that you can't have a folder on a bucket root called "..", and also that S3 reads ".."
+		// literally, not as a symbol for a parent folder). 
 
 		if (contentEncoding.length > 0) {
 			_.assign(fileOptions, {


### PR DESCRIPTION
Convert backslashes from win32 paths to slashes, as S3 requires.